### PR TITLE
Rename some fields and fix some nits

### DIFF
--- a/draft-davidson-pp-protocol.md
+++ b/draft-davidson-pp-protocol.md
@@ -157,7 +157,7 @@ already in prime-order groups, and constructions are currently being
 drafted in separate standardization processes {{I-D.irtf-cfrg-voprf}}.
 
 The Privacy Pass protocol is split into three stages. The first stage,
-"initialisation," produces the global server configuration that is
+"initialisation", produces the global server configuration that is
 broadcast to (and stored by) all clients. The "issuance" phase provides
 the client with unlinkable tokens that can be used to initiate
 re-authorization with the server in the future. The "redemption" phase


### PR DESCRIPTION
Rename IssuanceMessage and RedemptionMessage to IssuanceRequest and RedemptionRequest, respectively. Rename SecretKey to PrivateKey. Change `max_evals` to an integer value, rather than opaque vector.

I also removed company-specific information, which is not really relevant for the document. (That's useful information, but not appropriate for a standards document, I think.)

cc @alxdavids @dvorak42 